### PR TITLE
tests: coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,5 +30,5 @@ jobs:
 
       - name: Run Forge tests
         run: |
-          forge test -vvv
+          forge test -vvv --code-size-limit 0x8000
         id: test

--- a/src/DutchAuction.sol
+++ b/src/DutchAuction.sol
@@ -87,7 +87,7 @@ contract DutchAuction is BaseConditionalOrder {
 
         // `startTime` for the auction is either when the was mined or a specific start time
         if (data.startTime == 0) {
-            data.startTime = uint32(bytes4(composableCow.cabinet(owner, ctx)));
+            data.startTime = uint32(uint256(composableCow.cabinet(owner, ctx)));
         }
 
         // woah there! you're too early and the auction hasn't started. Come back later.

--- a/src/DutchAuction.sol
+++ b/src/DutchAuction.sol
@@ -27,6 +27,8 @@ string constant ERR_MIN_STEP_DISCOUNT = "stepDiscount is zero";
 string constant ERR_MAX_STEP_DISCOUNT = "stepDiscount is gte 10000";
 /// @dev number of steps is less than or equal to 1
 string constant ERR_MIN_NUM_STEPS = "numSteps is lte 1";
+/// @dev total discount is greater than 10000
+string constant ERR_MAX_TOTAL_DISCOUNT = "total discount is gt 10000";
 
 
 /**
@@ -173,5 +175,6 @@ contract DutchAuction is BaseConditionalOrder {
         if (data.stepDiscount == 0) revert OrderNotValid(ERR_MIN_STEP_DISCOUNT);
         if (data.stepDiscount >= 10000) revert OrderNotValid(ERR_MAX_STEP_DISCOUNT);
         if (data.numSteps <= 1) revert OrderNotValid(ERR_MIN_NUM_STEPS);
+        if (data.numSteps * data.stepDiscount > 10000) revert OrderNotValid(ERR_MAX_TOTAL_DISCOUNT);
     }
 }

--- a/test/DutchAuctionTest.t.sol
+++ b/test/DutchAuctionTest.t.sol
@@ -147,11 +147,19 @@ contract DutchAuctionTest is BaseComposableCoWTest {
         helper_runRevertingValidate(data, ERR_MIN_STEP_DISCOUNT);
     }
 
-    function test_validation_RevertWhenDiscountTooHigh() public {
+    function test_validation_RevertWhenStepDiscountTooHigh() public {
         DutchAuction.Data memory data = helper_testData();
         data.stepDiscount = 10000;
 
         helper_runRevertingValidate(data, ERR_MAX_STEP_DISCOUNT);
+    }
+
+    function test_validation_RevertWhenTotalDiscountTooHigh() public {
+        DutchAuction.Data memory data = helper_testData();
+        data.stepDiscount = 5000;
+        data.numSteps = 3;
+
+        helper_runRevertingValidate(data, ERR_MAX_TOTAL_DISCOUNT);
     }
 
     function test_validation_RevertWhenStepsInsufficient() public {


### PR DESCRIPTION
# Description
This PR provides test coverage, excluding end-to-end tests (`settle`).

# Changes

- [x] Concrete tests
- [x] Fuzz tests

## How to test

To test:

1. `forge test -vvv`

**NOTE**: Excludes reversion tests when `data.startTime = 0` (ie. based on mining time). To be handled in the next PR.

## Related Issues

Related #2