### PR TITLE
fix: add missing docs and check

### DIFF
--- a/docs/types/dutch-auction.md
+++ b/docs/types/dutch-auction.md
@@ -6,6 +6,18 @@ A simple _dutch auction_ may be thought of as a series of _limit orders_ where t
 
 This contract simplifies the _dutch auction_ by not selling on a continually decreasing price curve, but instead selling at a fixed price for a fixed period of time before discounting further. This approximation makes replay protection more intuitive / easier to reason, as well as eliminating the need for additional logic to be implemented within the watch-tower.
 
+### Discount Formulae
+
+This contract implements a linear "stair-step" discount formulae, where the price decreases by a fixed amount every `stepDuration` seconds. This discount formulae is as follows:
+
+`minimumBuyAmount = startBuyAmount - (stepIndex * stepDiscount  * startBuyAmount / 10000)`
+
+Where:
+- `minimumBuyAmount` is the minimum amount of `buyToken` that must be paid to fill the order.
+- `startBuyAmount` is the initial amount of `buyToken` at the start of the auction.
+- `stepIndex` is the 0-index of the current step in the auction.
+- `stepDiscount` is the amount of discount to apply to the `startBuyAmount` every `stepDuration` seconds. This is measured in BPS (1/10000).
+
 ## Data Structure
 
 * **Uses Cabinet**: ✅
@@ -59,6 +71,7 @@ The following `GPv2Order.Data` fields are calculated / auto-filled by the contra
 * `numSteps` MUST be at least 2
 * `stepDuration` MUST not be 0 seconds, and SHOULD be at least 3 mins (CoW Protocol API requires orders being placed to have a validity of at least 2 mins)
 * `stepDiscount` MUST be at least 1 BPS (1/10000) and MUST be less than 10000 BPS (100%)
+* `stepDiscount * numSteps` MUST be less than 10000 BPS (100%)
 * Does NOT support partial fills
 
 ### Replay Mitigation

--- a/src/DutchAuction.sol
+++ b/src/DutchAuction.sol
@@ -28,7 +28,7 @@ string constant ERR_MAX_STEP_DISCOUNT = "stepDiscount is gte 10000";
 /// @dev number of steps is less than or equal to 1
 string constant ERR_MIN_NUM_STEPS = "numSteps is lte 1";
 /// @dev total discount is greater than 10000
-string constant ERR_MAX_TOTAL_DISCOUNT = "total discount is gt 10000";
+string constant ERR_MAX_TOTAL_DISCOUNT = "total discount is gte 10000";
 
 /**
  * @title Simple Dutch Auction order type for CoW Protocol.
@@ -164,6 +164,6 @@ contract DutchAuction is BaseConditionalOrder {
         if (data.stepDiscount == 0) revert OrderNotValid(ERR_MIN_STEP_DISCOUNT);
         if (data.stepDiscount >= 10000) revert OrderNotValid(ERR_MAX_STEP_DISCOUNT);
         if (data.numSteps <= 1) revert OrderNotValid(ERR_MIN_NUM_STEPS);
-        if (data.numSteps * data.stepDiscount > 10000) revert OrderNotValid(ERR_MAX_TOTAL_DISCOUNT);
+        if (data.numSteps * data.stepDiscount >= 10000) revert OrderNotValid(ERR_MAX_TOTAL_DISCOUNT);
     }
 }


### PR DESCRIPTION
# Description
The previous PR #9 missed some documentation and checks. This PR adds them.

# Changes

- [x] Explicit documentation of discount formulae
- [x] Explicit total discount check

## How to test

1. Read the documentation
2. Verify it makes sense