### PR TITLE
fix: remove extraneous salt

### DIFF
--- a/script/Deploy.s.sol
+++ b/script/Deploy.s.sol
@@ -15,6 +15,6 @@ contract Deploy is Script {
         vm.startBroadcast(deployerPrivateKey);
 
         // Deploy DutchAuction
-        new DutchAuction{salt: "v0.0.1"}(ComposableCoW(composableCow));
+        new DutchAuction{salt: ""}(ComposableCoW(composableCow));
     }
 }


### PR DESCRIPTION
# Description
This PR addresses comments in #9 surrounding the use of the `salt` when deploying the order type.

# Changes

- [x] Removed version string in favour of a zero-length salt

## How to test

1. Deploy to chain A and chain B.
2. Confirm that both deployment addresses are the same.